### PR TITLE
fix [android]: speaking alway

### DIFF
--- a/android/src/main/kotlin/com/tundralabs/fluttertts/FlutterTtsPlugin.kt
+++ b/android/src/main/kotlin/com/tundralabs/fluttertts/FlutterTtsPlugin.kt
@@ -573,6 +573,8 @@ class FlutterTtsPlugin : MethodCallHandler, FlutterPlugin {
     }
 
     private fun stop() {
+        if (awaitSynthCompletion) synth = false
+        if (awaitSpeakCompletion) speaking = false
         tts!!.stop()
     }
 


### PR DESCRIPTION
set speaking and synth to false in the stop method to avoid there is no callback.